### PR TITLE
Hide upgrade modal and widget on lesson page

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -7,3 +7,15 @@ section[data-testid='sidebar-NOTIFICATIONS'] {
 section[data-testid='sidebar-DISCUSSIONS_NOTIFICATIONS'] {
   display: none !important;
 }
+
+/* section above each exercise encouraging users to upgrade to unlock each exercise */
+
+div[data-testid='lock-paywall-test-id'] {
+  display: none !important;
+}
+
+/* upgrade modal that covers the whole page */
+
+.pgn__modal-layer {
+  display: none !important;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
Removes some additional paywall modals and collapsible sections. 
<!--- Describe your changes in detail -->

## Background

There are constant encouragements to upgrade to a paid certificate. These can be distracting to users and take away from the value of the course. This extension hides the prompts by default. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can load the unpacked extension into a Chromium based browser. When you use edx you shouldn't see a modal appear to cover the entire page and encourage an upgrade, and on the page for each exercise, you shouldn't see a prompt to upgrade because the exercise is locked. 

<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):
<img width="983" alt="Screen Shot 2025-03-06 at 8 58 07 AM" src="https://github.com/user-attachments/assets/fb72b132-43e5-4821-a75b-e5613d2b2653" />

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.
